### PR TITLE
Replace deprecated ioutil.ReadAll with io.ReadAll

### DIFF
--- a/gol.go
+++ b/gol.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -36,7 +36,7 @@ func Request(url string) (Container, error) {
 	}
 
 	defer resp.Body.Close()
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyBytes, _ := io.ReadAll(resp.Body)
 	dec := json.NewDecoder(bytes.NewReader(bodyBytes))
 	dec.UseNumber()
 	container, err := gabs.ParseJSONDecoder(dec)


### PR DESCRIPTION
Standard library Package ioutil has been deprecated as of Go 1.16, behaviour has moved to Package io or os.

